### PR TITLE
use unwrapped class; account for theme prop

### DIFF
--- a/src-docs/src/services/playground/props.js
+++ b/src-docs/src/services/playground/props.js
@@ -63,12 +63,19 @@ const getProp = (prop) => {
   return newProp;
 };
 
-const propUtilityForPlayground = (props) => {
+const propUtilityForPlayground = (props, withTheme = false) => {
   const modifiedProps = {};
 
-  for (const key in props) {
-    if (props[key].type) modifiedProps[key] = getProp(props[key]);
+  if (withTheme) {
+    delete props.theme;
   }
+
+  for (const key in props) {
+    if (props[key].type) {
+      modifiedProps[key] = getProp(props[key]);
+    }
+  }
+
   return modifiedProps;
 };
 

--- a/src-docs/src/views/accordion/playground.js
+++ b/src-docs/src/views/accordion/playground.js
@@ -1,5 +1,6 @@
 import { PropTypes } from 'react-view';
 import { EuiAccordion, EuiPanel } from '../../../../src/components/';
+import { EuiAccordionClass } from '../../../../src/components/accordion/accordion';
 import { htmlIdGenerator } from '../../../../src/services';
 import {
   propUtilityForPlayground,
@@ -9,10 +10,10 @@ import {
 } from '../../services/playground';
 
 export const accordionConfig = () => {
-  const docgenInfo = Array.isArray(EuiAccordion.__docgenInfo)
-    ? EuiAccordion.__docgenInfo[0]
-    : EuiAccordion.__docgenInfo;
-  const propsToUse = propUtilityForPlayground(docgenInfo.props);
+  const docgenInfo = Array.isArray(EuiAccordionClass.__docgenInfo)
+    ? EuiAccordionClass.__docgenInfo[0]
+    : EuiAccordionClass.__docgenInfo;
+  const propsToUse = propUtilityForPlayground(docgenInfo.props, true);
 
   propsToUse.buttonContent = {
     ...propsToUse.buttonContent,

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -103,7 +103,7 @@ export type EuiAccordionProps = CommonProps &
     isLoadingMessage?: boolean | ReactNode;
   };
 
-class EuiAccordionClass extends Component<
+export class EuiAccordionClass extends Component<
   WithEuiThemeProps & EuiAccordionProps,
   { isOpen: boolean }
 > {
@@ -284,7 +284,10 @@ class EuiAccordionClass extends Component<
 
     if (extraAction) {
       optionalAction = (
-        <div className="euiAccordion__optionalAction" css={optionalActionStyles}>
+        <div
+          className="euiAccordion__optionalAction"
+          css={optionalActionStyles}
+        >
           {isLoading ? <EuiLoadingSpinner /> : extraAction}
         </div>
       );
@@ -328,7 +331,10 @@ class EuiAccordionClass extends Component<
 
     return (
       <Element className={classes} {...rest}>
-        <div className="euiAccordion__triggerWrapper" css={triggerWrapperStyles}>
+        <div
+          className="euiAccordion__triggerWrapper"
+          css={triggerWrapperStyles}
+        >
           {_arrowDisplay === 'left' && iconButton}
           {button}
           {optionalAction}


### PR DESCRIPTION
The playground setup doesn't know how to look inside the `WithEuiTheme` HOC for the real component, so we'll just do it explicitly.

Also, omit the `theme` prop because it's added automatically and consumers don't need to be aware. 
